### PR TITLE
Fix double symbols push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
       run: |
           if ( "${{github.ref}}" -match "^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" ) {
               dotnet nuget push build\packages\**\*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_TOKEN}}
-              dotnet nuget push build\packages\**\*.snupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_TOKEN}}
           } else {
               echo "publish is only enabled by tagging with a release tag"
           }


### PR DESCRIPTION
No need to create a release now (unless you want to test specifically if this will fix that build failure), since the 1.3.18 works perfectly, even if build status is set as failed.