### PR TITLE
`Matrix3x3`: Add constructor overload that accepts a span of floats

### DIFF
--- a/src/Vortice.Mathematics/Matrix3x3.cs
+++ b/src/Vortice.Mathematics/Matrix3x3.cs
@@ -99,23 +99,57 @@ public readonly struct Matrix3x3
         float m21, float m22, float m23,
         float m31, float m32, float m33)
     {
-        M11 = m11; M12 = m12; M13 = m13;
-        M21 = m21; M22 = m22; M23 = m23;
-        M31 = m31; M32 = m32; M33 = m33;
+        M11 = m11;
+        M12 = m12;
+        M13 = m13;
+        M21 = m21;
+        M22 = m22;
+        M23 = m23;
+        M31 = m31;
+        M32 = m32;
+        M33 = m33;
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Matrix3x3"/> struct.
     /// </summary>
-    /// <param name="values">The values to assign to the components of the Matrix3x3. This must be an array with sixteen elements.</param>
+    /// <param name="values">The values to assign to the components of the Matrix3x3. This must be an array with nine elements.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than sixteen elements.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than nine elements.</exception>
     public Matrix3x3(float[] values)
     {
         if (values == null)
             throw new ArgumentNullException(nameof(values));
         if (values.Length != 9)
-            throw new ArgumentOutOfRangeException(nameof(values), "There must be only nine input values for Matrix3x3.");
+            throw new ArgumentOutOfRangeException(nameof(values),
+                "There must be only nine input values for Matrix3x3.");
+
+        M11 = values[0];
+        M12 = values[1];
+        M13 = values[2];
+
+        M21 = values[3];
+        M22 = values[4];
+        M23 = values[5];
+
+        M31 = values[6];
+        M32 = values[7];
+        M33 = values[8];
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Matrix3x3"/> struct.
+    /// </summary>
+    /// <param name="values">The values to assign to the components of the Matrix3x3. This must be a span with nine elements.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than nine elements.</exception>
+    public Matrix3x3(ReadOnlySpan<float> values)
+    {
+        if (values == null)
+            throw new ArgumentNullException(nameof(values));
+        if (values.Length != 9)
+            throw new ArgumentOutOfRangeException(nameof(values),
+                "There must be only nine input values for Matrix3x3.");
 
         M11 = values[0];
         M12 = values[1];

--- a/src/Vortice.Mathematics/Matrix3x3.cs
+++ b/src/Vortice.Mathematics/Matrix3x3.cs
@@ -99,15 +99,9 @@ public readonly struct Matrix3x3
         float m21, float m22, float m23,
         float m31, float m32, float m33)
     {
-        M11 = m11;
-        M12 = m12;
-        M13 = m13;
-        M21 = m21;
-        M22 = m22;
-        M23 = m23;
-        M31 = m31;
-        M32 = m32;
-        M33 = m33;
+        M11 = m11; M12 = m12; M13 = m13;
+        M21 = m21; M22 = m22; M23 = m23;
+        M31 = m31; M32 = m32; M33 = m33;
     }
 
     /// <summary>


### PR DESCRIPTION
Hi @amerkoleci,

I've noticed that there is a constructor overload for `Matrix3x3` that accepts `float[]`, but not one for spans (which is more convenient in my use case). 
This PR adds such overload. 
I also fixed the documentation.