### PR TITLE
Fix non-hardware-accelerated implementation of `Vector128<float>.Clamp` extension

### DIFF
--- a/src/Vortice.Mathematics/VectorUtilities.cs
+++ b/src/Vortice.Mathematics/VectorUtilities.cs
@@ -568,8 +568,16 @@ public static unsafe class VectorUtilities
         }
         else
         {
-            return Clamp(vector, Vector128<float>.Zero, One);
+            return SoftwareFallback(vector);
         }
+
+        static Vector128<float> SoftwareFallback(Vector128<float> vector)
+            => Vector128.Create(
+                MathF.Truncate(vector.GetX()),
+                MathF.Truncate(vector.GetY()),
+                MathF.Truncate(vector.GetZ()),
+                MathF.Truncate(vector.GetW())
+            );
     }
 
 


### PR DESCRIPTION
per https://github.com/amerkoleci/Vortice.Mathematics/commit/ebbb88363769e1502dbab3906ee4df05d0c52274#r142972609